### PR TITLE
Api changes

### DIFF
--- a/lib/taskmaster.ex
+++ b/lib/taskmaster.ex
@@ -111,19 +111,19 @@ defmodule Taskmaster do
 
   @impl true
   def handle_cast({:"$taskmaster_all", funs, opts}, %{caller: caller} = state) do
-    results =
+    funs_results =
       funs
       |> run_concurrently(ordered: true, timeout: opts[:timeout])
       |> values()
       |> results_if_all(&correct_result?/1)
 
-    message =
-      case results do
-        [error] when is_error(error) -> {:all_error, error}
-        elements -> {:all_return_values, elements}
+    result =
+      case funs_results do
+        [error] when is_error(error) -> {:error, error}
+        elements -> elements
       end
 
-    send(caller, message)
+    send(caller, %Taskmaster.Result{action: :all, result: result})
 
     {:stop, :normal, state}
   end

--- a/lib/taskmaster/result.ex
+++ b/lib/taskmaster/result.ex
@@ -1,0 +1,4 @@
+defmodule Taskmaster.Result do
+  @enforce_keys [:action, :result]
+  defstruct [:action, :result]
+end

--- a/test/taskmaster_test.exs
+++ b/test/taskmaster_test.exs
@@ -43,7 +43,7 @@ defmodule TaskmasterTest do
         end
       ])
 
-      assert_receive {:race_won, :one}
+      assert_receive %Taskmaster.Result{action: :race, result: {:winner, :one}}
     end
 
     test "terminates the functions that lost the race" do
@@ -86,7 +86,10 @@ defmodule TaskmasterTest do
         end
       ])
 
-      assert_receive {:race_interrupted, {:error, %ErlangError{}}}
+      assert_receive %Taskmaster.Result{
+        action: :race,
+        result: {:interrupted, {:error, %ErlangError{}}}
+      }
     end
 
     test "returns an error, if the winning function returns an error tuple" do
@@ -104,7 +107,7 @@ defmodule TaskmasterTest do
         end
       ])
 
-      assert_receive {:race_interrupted, {:error, :reason}}
+      assert_receive %Taskmaster.Result{action: :race, result: {:interrupted, {:error, :reason}}}
     end
 
     test "returns :timeout as a result, if the fastest function still exceeds the :timeout option" do
@@ -126,7 +129,7 @@ defmodule TaskmasterTest do
         timeout: 50
       )
 
-      assert_receive {:race_interrupted, :timeout}
+      assert_receive %Taskmaster.Result{action: :race, result: {:interrupted, :timeout}}
     end
   end
 

--- a/test/taskmaster_test.exs
+++ b/test/taskmaster_test.exs
@@ -179,8 +179,8 @@ defmodule TaskmasterTest do
         end
       ])
 
-      refute_received {:all_return_values, [:one, :two, :three]}
-      assert_receive {:all_return_values, [:one, :two, :three]}, 400
+      refute_received %Taskmaster.Result{action: :all, result: [:one, :two, :three]}
+      assert_receive %Taskmaster.Result{action: :all, result: [:one, :two, :three]}, 400
     end
 
     test "sends an error message to the caller if one of the functions raises en error" do
@@ -198,7 +198,8 @@ defmodule TaskmasterTest do
         end
       ])
 
-      assert_receive {:all_error, {:error, %ErlangError{}}}, 500
+      assert_receive %Taskmaster.Result{action: :all, result: {:error, {:error, %ErlangError{}}}},
+                     500
     end
 
     test "sends an error message to the caller if one of the functions retuns an error tuple" do
@@ -216,7 +217,7 @@ defmodule TaskmasterTest do
         end
       ])
 
-      assert_receive {:all_error, {:error, reason}}, 500
+      assert_receive %Taskmaster.Result{action: :all, result: {:error, {:error, :reason}}}, 500
     end
 
     test "sends an error message to the caller if one of the functions times out" do
@@ -237,7 +238,7 @@ defmodule TaskmasterTest do
         timeout: 100
       )
 
-      assert_receive {:all_error, {:exit, :timeout}}, 500
+      assert_receive %Taskmaster.Result{action: :all, result: {:error, {:exit, :timeout}}}, 500
     end
   end
 end


### PR DESCRIPTION
All messages sent to the caller process use the `Taskmaster.Result` struct.